### PR TITLE
Fix enduser namespace bloat

### DIFF
--- a/library/examples/basic/basic.ino
+++ b/library/examples/basic/basic.ino
@@ -5,13 +5,13 @@
 #define MESH_PASSWORD "ramen123*"
 #define MESH_PORT     5555
 
-ramen::server::Server consensus_on_mesh;
+ramenServer consensus_on_mesh_server;
 
 void setup() {
   Serial.begin(115200);
-  consensus_on_mesh.init(MESH_NAME, MESH_PASSWORD, MESH_PORT);
+  consensus_on_mesh_server.init(MESH_NAME, MESH_PASSWORD, MESH_PORT);
 }
 
 void loop() {
-  consensus_on_mesh.update();
+  consensus_on_mesh_server.update();
 }

--- a/library/src/ramen.h
+++ b/library/src/ramen.h
@@ -12,4 +12,6 @@
 #include "ramen/logger.hpp"
 #include "ramen/server.hpp"
 
+using ramenServer = ramen::server::Server;
+
 #endif


### PR DESCRIPTION
- adds `using` keyword to reduce bloat in `ramen.h`
- update example to reflect change